### PR TITLE
ignore bundle.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /node_modules
+bundle.js


### PR DESCRIPTION
Adds webpack's output `bundle.js` to the .gitignore file. Will also ignore `bundle.js.map`, which is nice.

Won't affect John McC's PR. 